### PR TITLE
lsコマンドを作るオブジェクト指向版

### DIFF
--- a/07.ls_object/bin/ls.rb
+++ b/07.ls_object/bin/ls.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'optparse'
+require_relative '../lib/ls_command'
+
+opt = OptionParser.new
+
+params = { dot_match: false, long_format: false, reverse: false }
+opt.on('-a') { |v| params[:dot_match] = v }
+opt.on('-l') { |v| params[:long_format] = v }
+opt.on('-r') { |v| params[:reverse] = v }
+opt.parse!(ARGV)
+path = ARGV[0] || '.'
+
+puts LsCommand.new(path, **params).run

--- a/07.ls_object/lib/base_directory.rb
+++ b/07.ls_object/lib/base_directory.rb
@@ -17,6 +17,23 @@ class BaseDirectory
     file_names.map(&:size).max
   end
 
+  def file_attributes
+    @file_attributes ||= @files.map(&:attribute)
+  end
+
+  def total_blocks
+    file_attributes.sum(&:blocks)
+  end
+
+  def max_sizes
+    [
+      file_attributes.map(&:nlinks).max.to_s.size,
+      file_attributes.map { |file_attribute| file_attribute.user_name.size }.max,
+      file_attributes.map { |file_attribute| file_attribute.group_name.size }.max,
+      file_attributes.map(&:size).max.to_s.size
+    ]
+  end
+
   private
 
   def collect_file_names(path, dot_match, reverse)

--- a/07.ls_object/lib/base_directory.rb
+++ b/07.ls_object/lib/base_directory.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require_relative 'ls_file'
+
+class BaseDirectory
+  def initialize(path, dot_match: false, reverse: false)
+    @path = path
+    file_names = collect_file_names(path, dot_match, reverse)
+    @files = file_names.map { |file_name| LsFile.new(path, file_name) }.freeze
+  end
+
+  def file_names
+    @files.map(&:name)
+  end
+
+  def max_file_name_length
+    file_names.map(&:size).max
+  end
+
+  private
+
+  def collect_file_names(path, dot_match, reverse)
+    file_names_with_dot = Dir.entries(path).sort
+    file_names = dot_match ? file_names_with_dot : file_names_with_dot.reject { |file_name| file_name[0] == '.' }
+    reverse ? file_names.reverse : file_names
+  end
+end

--- a/07.ls_object/lib/base_directory.rb
+++ b/07.ls_object/lib/base_directory.rb
@@ -3,6 +3,8 @@
 require_relative 'ls_file'
 
 class BaseDirectory
+  attr_reader :files
+
   def initialize(path, dot_match: false, reverse: false)
     @path = path
     file_names = collect_file_names(path, dot_match, reverse)
@@ -17,20 +19,16 @@ class BaseDirectory
     file_names.map(&:size).max
   end
 
-  def file_attributes
-    @file_attributes ||= @files.map(&:attribute)
-  end
-
   def total_blocks
-    file_attributes.sum(&:blocks)
+    files.sum(&:blocks)
   end
 
   def max_sizes
     [
-      file_attributes.map(&:nlinks).max.to_s.size,
-      file_attributes.map { |file_attribute| file_attribute.user_name.size }.max,
-      file_attributes.map { |file_attribute| file_attribute.group_name.size }.max,
-      file_attributes.map(&:size).max.to_s.size
+      files.map(&:nlinks).max.to_s.size,
+      files.map { |file| file.user_name.size }.max,
+      files.map { |file| file.group_name.size }.max,
+      files.map(&:size).max.to_s.size
     ]
   end
 

--- a/07.ls_object/lib/long_formatter.rb
+++ b/07.ls_object/lib/long_formatter.rb
@@ -35,9 +35,9 @@ class LongFormatter
 
   def format_timestamp(timestamp)
     if Date.parse(timestamp.to_s) > Date.today.prev_month(6)
-      timestamp.strftime('%_2m %_2d %H:%M')
+      timestamp.strftime('%b %_2d %H:%M')
     else
-      timestamp.strftime('%_2m %_2d %_5Y')
+      timestamp.strftime('%b %_2d %_5Y')
     end
   end
 end

--- a/07.ls_object/lib/long_formatter.rb
+++ b/07.ls_object/lib/long_formatter.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'date'
+
+class LongFormatter
+  def format(base_directory)
+    row_data = base_directory.file_attributes
+    return 'total 0' if row_data.empty?
+
+    total = "total #{base_directory.total_blocks}"
+    max_sizes = base_directory.max_sizes
+    body = format_body(row_data, max_sizes)
+    [total, *body].join("\n")
+  end
+
+  private
+
+  def format_body(row_data, max_sizes)
+    row_data.map do |data|
+      format_row(data, *max_sizes)
+    end
+  end
+
+  def format_row(attribute, max_nlinks, max_user, max_group, max_size)
+    [
+      attribute.type_and_mode,
+      "  #{attribute.nlinks.to_s.rjust(max_nlinks)}",
+      " #{attribute.user_name.ljust(max_user)}",
+      "  #{attribute.group_name.ljust(max_group)}",
+      "  #{attribute.size.to_s.rjust(max_size)}",
+      " #{format_timestamp(attribute.mtime)}",
+      " #{attribute.file_name}"
+    ].join
+  end
+
+  def format_timestamp(timestamp)
+    if Date.parse(timestamp.to_s) > Date.today.prev_month(6)
+      timestamp.strftime('%_2m %_2d %H:%M')
+    else
+      timestamp.strftime('%_2m %_2d %_5Y')
+    end
+  end
+end

--- a/07.ls_object/lib/long_formatter.rb
+++ b/07.ls_object/lib/long_formatter.rb
@@ -4,20 +4,20 @@ require 'date'
 
 class LongFormatter
   def format(base_directory)
-    row_data = base_directory.file_attributes
-    return 'total 0' if row_data.empty?
+    file_attributes = base_directory.file_attributes
+    return 'total 0' if file_attributes.empty?
 
     total = "total #{base_directory.total_blocks}"
     max_sizes = base_directory.max_sizes
-    body = format_body(row_data, max_sizes)
+    body = format_body(file_attributes, max_sizes)
     [total, *body].join("\n")
   end
 
   private
 
-  def format_body(row_data, max_sizes)
-    row_data.map do |data|
-      format_row(data, *max_sizes)
+  def format_body(file_attributes, max_sizes)
+    file_attributes.map do |attribute|
+      format_row(attribute, *max_sizes)
     end
   end
 

--- a/07.ls_object/lib/long_formatter.rb
+++ b/07.ls_object/lib/long_formatter.rb
@@ -5,8 +5,6 @@ require 'date'
 class LongFormatter
   def format(base_directory)
     file_attributes = base_directory.file_attributes
-    return 'total 0' if file_attributes.empty?
-
     total = "total #{base_directory.total_blocks}"
     max_sizes = base_directory.max_sizes
     body = format_body(file_attributes, max_sizes)

--- a/07.ls_object/lib/long_formatter.rb
+++ b/07.ls_object/lib/long_formatter.rb
@@ -4,30 +4,30 @@ require 'date'
 
 class LongFormatter
   def format(base_directory)
-    file_attributes = base_directory.file_attributes
+    files = base_directory.files
     total = "total #{base_directory.total_blocks}"
     max_sizes = base_directory.max_sizes
-    body = format_body(file_attributes, max_sizes)
+    body = format_body(files, max_sizes)
     [total, *body].join("\n")
   end
 
   private
 
-  def format_body(file_attributes, max_sizes)
-    file_attributes.map do |attribute|
-      format_row(attribute, *max_sizes)
+  def format_body(files, max_sizes)
+    files.map do |file|
+      format_row(file, *max_sizes)
     end
   end
 
-  def format_row(attribute, max_nlinks, max_user, max_group, max_size)
+  def format_row(file, max_nlinks, max_user, max_group, max_size)
     [
-      attribute.type_and_mode,
-      "  #{attribute.nlinks.to_s.rjust(max_nlinks)}",
-      " #{attribute.user_name.ljust(max_user)}",
-      "  #{attribute.group_name.ljust(max_group)}",
-      "  #{attribute.size.to_s.rjust(max_size)}",
-      " #{format_timestamp(attribute.mtime)}",
-      " #{attribute.file_name}"
+      file.type_and_mode,
+      "  #{file.nlinks.to_s.rjust(max_nlinks)}",
+      " #{file.user_name.ljust(max_user)}",
+      "  #{file.group_name.ljust(max_group)}",
+      "  #{file.size.to_s.rjust(max_size)}",
+      " #{format_timestamp(file.mtime)}",
+      " #{file.name}"
     ].join
   end
 

--- a/07.ls_object/lib/ls_command.rb
+++ b/07.ls_object/lib/ls_command.rb
@@ -1,22 +1,15 @@
 # frozen_string_literal: true
 
+require_relative 'base_directory'
 require_relative 'short_formatter'
 
 class LsCommand
   def initialize(path, dot_match: false, reverse: false)
-    @file_names = collect_file_names(path, dot_match, reverse).freeze
+    @base_directory = BaseDirectory.new(path, dot_match:, reverse:)
     @formatter = ShortFormatter.new
   end
 
   def run
-    @formatter.format(@file_names)
-  end
-
-  private
-
-  def collect_file_names(path, dot_match, reverse)
-    file_names_with_dot = Dir.entries(path).sort
-    file_names = dot_match ? file_names_with_dot : file_names_with_dot.reject { |file_name| file_name[0] == '.' }
-    reverse ? file_names.reverse : file_names
+    @formatter.format(@base_directory)
   end
 end

--- a/07.ls_object/lib/ls_command.rb
+++ b/07.ls_object/lib/ls_command.rb
@@ -1,12 +1,13 @@
 # frozen_string_literal: true
 
 require_relative 'base_directory'
+require_relative 'long_formatter'
 require_relative 'short_formatter'
 
 class LsCommand
-  def initialize(path, dot_match: false, reverse: false)
+  def initialize(path, dot_match: false, long_format: false, reverse: false)
     @base_directory = BaseDirectory.new(path, dot_match:, reverse:)
-    @formatter = ShortFormatter.new
+    @formatter = long_format ? LongFormatter.new : ShortFormatter.new
   end
 
   def run

--- a/07.ls_object/lib/ls_command.rb
+++ b/07.ls_object/lib/ls_command.rb
@@ -3,8 +3,8 @@
 require_relative 'short_formatter'
 
 class LsCommand
-  def initialize(path)
-    @file_names = collect_file_names(path).freeze
+  def initialize(path, dot_match: false)
+    @file_names = collect_file_names(path, dot_match).freeze
     @formatter = ShortFormatter.new
   end
 
@@ -14,8 +14,8 @@ class LsCommand
 
   private
 
-  def collect_file_names(path)
+  def collect_file_names(path, dot_match)
     file_names = Dir.entries(path).sort
-    file_names.reject { |file_name| file_name[0] == '.' }
+    dot_match ? file_names : file_names.reject { |file_name| file_name[0] == '.' }
   end
 end

--- a/07.ls_object/lib/ls_command.rb
+++ b/07.ls_object/lib/ls_command.rb
@@ -3,8 +3,8 @@
 require_relative 'short_formatter'
 
 class LsCommand
-  def initialize(path, dot_match: false)
-    @file_names = collect_file_names(path, dot_match).freeze
+  def initialize(path, dot_match: false, reverse: false)
+    @file_names = collect_file_names(path, dot_match, reverse).freeze
     @formatter = ShortFormatter.new
   end
 
@@ -14,8 +14,9 @@ class LsCommand
 
   private
 
-  def collect_file_names(path, dot_match)
-    file_names = Dir.entries(path).sort
-    dot_match ? file_names : file_names.reject { |file_name| file_name[0] == '.' }
+  def collect_file_names(path, dot_match, reverse)
+    file_names_with_dot = Dir.entries(path).sort
+    file_names = dot_match ? file_names_with_dot : file_names_with_dot.reject { |file_name| file_name[0] == '.' }
+    reverse ? file_names.reverse : file_names
   end
 end

--- a/07.ls_object/lib/ls_command.rb
+++ b/07.ls_object/lib/ls_command.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require_relative 'short_formatter'
+
+class LsCommand
+  def initialize(path)
+    @file_names = collect_file_names(path).freeze
+    @formatter = ShortFormatter.new
+  end
+
+  def run
+    @formatter.format(@file_names)
+  end
+
+  private
+
+  def collect_file_names(path)
+    file_names = Dir.entries(path).sort
+    file_names.reject { |file_name| file_name[0] == '.' }
+  end
+end

--- a/07.ls_object/lib/ls_file.rb
+++ b/07.ls_object/lib/ls_file.rb
@@ -1,10 +1,59 @@
 # frozen_string_literal: true
 
+require 'etc'
+
 class LsFile
+  TYPE_TABLE = {
+    '04' => 'd',
+    '10' => '-'
+  }.freeze
+  MODE_TABLE = {
+    '0' => '---',
+    '1' => '--x',
+    '2' => '-w-',
+    '3' => '-wx',
+    '4' => 'r--',
+    '5' => 'r-x',
+    '6' => 'rw-',
+    '7' => 'rwx'
+  }.freeze
+
+  Attribute = Data.define(:type_and_mode, :nlinks, :user_name, :group_name, :size, :mtime, :file_name, :blocks)
+
   attr_reader :name
 
   def initialize(parent_path, name)
     @parent_path = parent_path
     @name = name
+  end
+
+  def attribute
+    stat = File.lstat(path)
+    Attribute.new(
+      type_and_mode_text(stat.mode),
+      stat.nlink,
+      Etc.getpwuid(stat.uid).name,
+      Etc.getgrgid(stat.gid).name,
+      stat.size,
+      stat.mtime,
+      @name,
+      stat.blocks
+    )
+  end
+
+  private
+
+  def path
+    File.join(@parent_path, @name)
+  end
+
+  def type_and_mode_text(mode)
+    mode_text = mode.to_s(8).rjust(6, '0')
+    type = TYPE_TABLE[mode_text[0, 2]]
+    user_permission = MODE_TABLE[mode_text[3]]
+    group_permission = MODE_TABLE[mode_text[4]]
+    other_permission = MODE_TABLE[mode_text[5]]
+
+    "#{type}#{user_permission}#{group_permission}#{other_permission}"
   end
 end

--- a/07.ls_object/lib/ls_file.rb
+++ b/07.ls_object/lib/ls_file.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class LsFile
+  attr_reader :name
+
+  def initialize(parent_path, name)
+    @parent_path = parent_path
+    @name = name
+  end
+end

--- a/07.ls_object/lib/ls_file.rb
+++ b/07.ls_object/lib/ls_file.rb
@@ -50,10 +50,7 @@ class LsFile
   def type_and_mode_text(mode)
     mode_text = mode.to_s(8).rjust(6, '0')
     type = TYPE_TABLE[mode_text[0, 2]]
-    user_permission = MODE_TABLE[mode_text[3]]
-    group_permission = MODE_TABLE[mode_text[4]]
-    other_permission = MODE_TABLE[mode_text[5]]
-
-    "#{type}#{user_permission}#{group_permission}#{other_permission}"
+    permissions = mode_text[3, 5].gsub(/./, MODE_TABLE)
+    "#{type}#{permissions}"
   end
 end

--- a/07.ls_object/lib/ls_file.rb
+++ b/07.ls_object/lib/ls_file.rb
@@ -18,27 +18,20 @@ class LsFile
     '7' => 'rwx'
   }.freeze
 
-  Attribute = Data.define(:type_and_mode, :nlinks, :user_name, :group_name, :size, :mtime, :file_name, :blocks)
-
-  attr_reader :name
+  attr_reader :name, :type_and_mode, :nlinks, :user_name, :group_name, :size, :mtime, :blocks
 
   def initialize(parent_path, name)
     @parent_path = parent_path
     @name = name
-  end
 
-  def attribute
     stat = File.lstat(path)
-    Attribute.new(
-      type_and_mode_text(stat.mode),
-      stat.nlink,
-      Etc.getpwuid(stat.uid).name,
-      Etc.getgrgid(stat.gid).name,
-      stat.size,
-      stat.mtime,
-      @name,
-      stat.blocks
-    )
+    @type_and_mode = type_and_mode_text(stat.mode)
+    @nlinks = stat.nlink
+    @user_name = Etc.getpwuid(stat.uid).name
+    @group_name = Etc.getgrgid(stat.gid).name
+    @size = stat.size
+    @mtime = stat.mtime
+    @blocks = stat.blocks
   end
 
   private

--- a/07.ls_object/lib/short_formatter.rb
+++ b/07.ls_object/lib/short_formatter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class ShortFormatter
+  COLUMN_WIDTH_UNIT = 8
+  N_COLUMNS = 3
+
+  def format(file_names)
+    return '' if file_names.empty?
+
+    max_name_length = file_names.map(&:size).max
+    column_width = (max_name_length + 1).ceildiv(COLUMN_WIDTH_UNIT) * COLUMN_WIDTH_UNIT
+    n_rows = file_names.size.ceildiv(N_COLUMNS)
+    transposed_file_names = safe_transpose(file_names.each_slice(n_rows).to_a)
+    to_text(transposed_file_names, column_width)
+  end
+
+  private
+
+  def safe_transpose(nested_file_names)
+    nested_file_names[0].zip(*nested_file_names[1..])
+  end
+
+  def to_text(file_names, column_width)
+    file_names.map do |row_files|
+      format_row(row_files, column_width)
+    end.join("\n")
+  end
+
+  def format_row(row_files, column_width)
+    row_files.map do |file_name|
+      file_name.nil? ? '' : file_name.ljust(column_width)
+    end.join.rstrip
+  end
+end

--- a/07.ls_object/lib/short_formatter.rb
+++ b/07.ls_object/lib/short_formatter.rb
@@ -4,11 +4,11 @@ class ShortFormatter
   COLUMN_WIDTH_UNIT = 8
   N_COLUMNS = 3
 
-  def format(file_names)
+  def format(base_directory)
+    file_names = base_directory.file_names
     return '' if file_names.empty?
 
-    max_name_length = file_names.map(&:size).max
-    column_width = (max_name_length + 1).ceildiv(COLUMN_WIDTH_UNIT) * COLUMN_WIDTH_UNIT
+    column_width = (base_directory.max_file_name_length + 1).ceildiv(COLUMN_WIDTH_UNIT) * COLUMN_WIDTH_UNIT
     n_rows = file_names.size.ceildiv(N_COLUMNS)
     transposed_file_names = safe_transpose(file_names.each_slice(n_rows).to_a)
     to_text(transposed_file_names, column_width)

--- a/07.ls_object/test/base_directory_test.rb
+++ b/07.ls_object/test/base_directory_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/base_directory'
+
+class BaseDirectoryTest < Minitest::Test
+  DIR_PATH = 'test/fixtures/sample-app'
+  EMPTY_DIR_PATH = 'test/fixtures/empty_dir'
+
+  def test_file_names
+    expected = %w[Gemfile Gemfile.lock README.md app.rb dbinit.sh public views]
+    assert_equal expected, BaseDirectory.new(DIR_PATH).file_names
+  end
+
+  def test_file_names_empty
+    assert_equal [], BaseDirectory.new(EMPTY_DIR_PATH).file_names
+  end
+
+  def test_max_file_name_length
+    expected = 'Gemfile.lock'.length # 12
+    assert_equal expected, BaseDirectory.new(DIR_PATH).max_file_name_length
+  end
+end

--- a/07.ls_object/test/fixtures/sample-app/.erb-lint.yml
+++ b/07.ls_object/test/fixtures/sample-app/.erb-lint.yml
@@ -1,0 +1,5 @@
+---
+glob: "**/*.erb"
+linters:
+  RequireInputAutocomplete:
+    enabled: false

--- a/07.ls_object/test/fixtures/sample-app/.gitignore
+++ b/07.ls_object/test/fixtures/sample-app/.gitignore
@@ -1,0 +1,29 @@
+*.rbc
+/.config
+/coverage/
+/InstalledFiles
+/pkg/
+/spec/reports/
+/spec/examples.txt
+/test/tmp/
+/test/version_tmp/
+/tmp/
+
+# Ignore Byebug command history file.
+.byebug_history
+
+## Documentation cache and generated files:
+/.yardoc/
+/_yardoc/
+/doc/
+/rdoc/
+
+## Environment normalization:
+/.bundle/
+/vendor/bundle
+/lib/bundler/man/
+
+# unless supporting rvm < 1.11.0 or doing something fancy, ignore this:
+.rvmrc
+
+/memos.csv

--- a/07.ls_object/test/fixtures/sample-app/.rubocop.yml
+++ b/07.ls_object/test/fixtures/sample-app/.rubocop.yml
@@ -1,0 +1,3 @@
+inherit_gem:
+  rubocop-fjord:
+    - "config/rubocop.yml"

--- a/07.ls_object/test/fixtures/sample-app/Gemfile
+++ b/07.ls_object/test/fixtures/sample-app/Gemfile
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+gem 'pg'
+gem 'rackup'
+gem 'sinatra'
+gem 'sinatra-contrib'
+gem 'webrick'
+
+group :development do
+  gem 'erb_lint', require: false
+  gem 'rubocop-fjord', require: false
+end

--- a/07.ls_object/test/fixtures/sample-app/Gemfile.lock
+++ b/07.ls_object/test/fixtures/sample-app/Gemfile.lock
@@ -1,0 +1,135 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    actionview (7.1.3.2)
+      activesupport (= 7.1.3.2)
+      builder (~> 3.1)
+      erubi (~> 1.11)
+      rails-dom-testing (~> 2.2)
+      rails-html-sanitizer (~> 1.6)
+    activesupport (7.1.3.2)
+      base64
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      mutex_m
+      tzinfo (~> 2.0)
+    ast (2.4.2)
+    base64 (0.2.0)
+    better_html (2.1.1)
+      actionview (>= 6.0)
+      activesupport (>= 6.0)
+      ast (~> 2.0)
+      erubi (~> 1.4)
+      parser (>= 2.4)
+      smart_properties
+    bigdecimal (3.1.7)
+    builder (3.2.4)
+    concurrent-ruby (1.2.3)
+    connection_pool (2.4.1)
+    crass (1.0.6)
+    drb (2.2.1)
+    erb_lint (0.5.0)
+      activesupport
+      better_html (>= 2.0.1)
+      parser (>= 2.7.1.4)
+      rainbow
+      rubocop
+      smart_properties
+    erubi (1.12.0)
+    i18n (1.14.4)
+      concurrent-ruby (~> 1.0)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    loofah (2.22.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.12.0)
+    minitest (5.22.3)
+    multi_json (1.15.0)
+    mustermann (3.0.0)
+      ruby2_keywords (~> 0.0.1)
+    mutex_m (0.2.0)
+    nokogiri (1.16.3-arm64-darwin)
+      racc (~> 1.4)
+    parallel (1.24.0)
+    parser (3.3.0.5)
+      ast (~> 2.4.1)
+      racc
+    pg (1.5.6)
+    racc (1.7.3)
+    rack (3.0.10)
+    rack-protection (4.0.0)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0, < 4)
+    rack-session (2.0.0)
+      rack (>= 3.0.0)
+    rackup (2.1.0)
+      rack (>= 3)
+      webrick (~> 1.8)
+    rails-dom-testing (2.2.0)
+      activesupport (>= 5.0.0)
+      minitest
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.6.0)
+      loofah (~> 2.21)
+      nokogiri (~> 1.14)
+    rainbow (3.1.1)
+    regexp_parser (2.9.0)
+    rexml (3.2.6)
+    rubocop (1.62.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml (>= 3.2.5, < 4.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.31.2)
+      parser (>= 3.3.0.4)
+    rubocop-fjord (0.3.0)
+      rubocop (>= 1.0)
+      rubocop-performance
+    rubocop-performance (1.21.0)
+      rubocop (>= 1.48.1, < 2.0)
+      rubocop-ast (>= 1.31.1, < 2.0)
+    ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
+    sinatra (4.0.0)
+      mustermann (~> 3.0)
+      rack (>= 3.0.0, < 4)
+      rack-protection (= 4.0.0)
+      rack-session (>= 2.0.0, < 3)
+      tilt (~> 2.0)
+    sinatra-contrib (4.0.0)
+      multi_json (>= 0.0.2)
+      mustermann (~> 3.0)
+      rack-protection (= 4.0.0)
+      sinatra (= 4.0.0)
+      tilt (~> 2.0)
+    smart_properties (1.17.0)
+    tilt (2.3.0)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
+    unicode-display_width (2.5.0)
+    webrick (1.8.1)
+
+PLATFORMS
+  arm64-darwin-22
+
+DEPENDENCIES
+  erb_lint
+  pg
+  rackup
+  rubocop-fjord
+  sinatra
+  sinatra-contrib
+  webrick
+
+BUNDLED WITH
+   2.4.10

--- a/07.ls_object/test/fixtures/sample-app/README.md
+++ b/07.ls_object/test/fixtures/sample-app/README.md
@@ -1,0 +1,19 @@
+# sinatra-memo-app
+
+FBCのプラクティス「Sinatraを使ってWebアプリケーションの基本を理解する」の課題
+
+## インストール
+
+    $ bundle install
+
+## データベースとテーブル作成
+
+PostgreSQLでユーザー`postgres`を追加した上で以下を実行。
+
+    $ ./dbinit.sh
+
+## 起動
+
+    $ bundle exec ruby app.rb
+
+上記を実行後 http://localhost:4567/memos にアクセスする。

--- a/07.ls_object/test/fixtures/sample-app/app.rb
+++ b/07.ls_object/test/fixtures/sample-app/app.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+require 'pg'
+require 'sinatra'
+require 'sinatra/reloader'
+
+DB_NAME = 'memo_app'
+USER = 'postgres'
+TABLE_NAME = 'memos'
+
+conn = PG.connect(dbname: DB_NAME, user: USER)
+
+def fetch_all_memos(conn)
+  conn.exec("SELECT * FROM #{TABLE_NAME}").values.map { |id, title, content| { id:, title:, content: } }
+end
+
+def create_memo(conn, params)
+  conn.exec_params("INSERT INTO #{TABLE_NAME} (title, content) VALUES ($1, $2)", [params[:title], params[:content]])
+end
+
+def select_memo_by_id(conn, memo_id)
+  conn.exec_params("SELECT * FROM #{TABLE_NAME} WHERE id = $1", [memo_id]).values.map { |id, title, content| { id:, title:, content: } }[0]
+end
+
+def update_memo(conn, memo_id, params)
+  conn.exec_params("UPDATE #{TABLE_NAME} SET (title, content) = ($1, $2) WHERE id = $3", [params[:title], params[:content], memo_id])
+end
+
+def delete_memo(conn, memo_id)
+  conn.exec_params("DELETE FROM #{TABLE_NAME} WHERE id = $1", [memo_id])
+end
+
+get '/memos' do
+  @title = 'memo list'
+  @memos = fetch_all_memos(conn)
+  erb :index
+end
+
+get '/memos/new' do
+  @title = 'new memo'
+  erb :new
+end
+
+post '/memos' do
+  create_memo(conn, params)
+  redirect '/memos'
+end
+
+get '/memos/:id' do |memo_id|
+  @title = 'show memo'
+  @memo = select_memo_by_id(conn, memo_id)
+  raise Sinatra::NotFound if @memo.nil?
+
+  erb :show
+end
+
+get '/memos/:id/edit' do |memo_id|
+  @title = 'edit memo'
+  @memo = select_memo_by_id(conn, memo_id)
+  raise Sinatra::NotFound if @memo.nil?
+
+  erb :edit
+end
+
+patch '/memos/:id' do |memo_id|
+  update_memo(conn, memo_id, params)
+  redirect '/memos'
+end
+
+delete '/memos/:id' do |memo_id|
+  delete_memo(conn, memo_id)
+  redirect '/memos'
+end
+
+not_found do
+  erb :not_found, layout: false
+end
+
+helpers do
+  def h(text)
+    Rack::Utils.escape_html(text)
+  end
+end

--- a/07.ls_object/test/fixtures/sample-app/dbinit.sh
+++ b/07.ls_object/test/fixtures/sample-app/dbinit.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+USER='postgres'
+DB_NAME='memo_app'
+TABLE_NAME='memos'
+
+CREATE_TABLE_SQL="CREATE TABLE ${TABLE_NAME} (
+  id serial NOT NULL,
+  title varchar(50),
+  content varchar(500),
+  PRIMARY KEY (id)
+);"
+
+createdb $DB_NAME -U $USER
+psql $DB_NAME -U $USER -c "$CREATE_TABLE_SQL"

--- a/07.ls_object/test/fixtures/sample-app/public/css/style.css
+++ b/07.ls_object/test/fixtures/sample-app/public/css/style.css
@@ -1,0 +1,29 @@
+@charset "UTF-8";
+
+p,
+li {
+  white-space: pre-wrap;
+}
+
+button > a {
+  text-decoration: none;
+  color: buttontext;
+}
+
+input[type="text"],
+textarea {
+  width: 50%;
+  margin-bottom: 0.5em;
+  padding: 0.5em;
+  border: solid 1px #aaa;
+  border-radius: 4px;
+  vertical-align: middle;
+}
+
+.container {
+  display: flex;
+}
+
+.container button {
+  margin-right: 0.5em;
+}

--- a/07.ls_object/test/fixtures/sample-app/views/edit.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/edit.erb
@@ -1,0 +1,10 @@
+<form action="/memos/<%= @memo[:id] %>" method="POST">
+  <div>
+    <input type="text" name="title" value="<%== @memo[:title] %>">
+  </div>
+  <div>
+    <textarea name="content" cols="30" rows="10"><%== @memo[:content] %></textarea>
+  </div>
+  <button>変更</button>
+  <input type="hidden" name="_method" value="PATCH">
+</form>

--- a/07.ls_object/test/fixtures/sample-app/views/index.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/index.erb
@@ -1,0 +1,7 @@
+<button><a href="/memos/new">追加</a></button>
+
+<ul>
+  <% @memos.each do |memo| %>
+    <li><a href="/memos/<%= memo[:id] %>"><%== memo[:title] %></a></li>
+  <% end %>
+</ul>

--- a/07.ls_object/test/fixtures/sample-app/views/layout.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/layout.erb
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <link rel="stylesheet" href="/css/style.css">
+  <title><%= @title %></title>
+</head>
+<body>
+  <h1>メモアプリ</h1>
+  <%= yield %>
+</body>
+</html>

--- a/07.ls_object/test/fixtures/sample-app/views/new.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/new.erb
@@ -1,0 +1,9 @@
+<form action="/memos" method="POST">
+  <div>
+    <input type="text" name="title" required>
+  </div>
+  <div>
+    <textarea name="content" cols="30" rows="10"></textarea>
+  </div>
+  <button>保存</button>
+</form>

--- a/07.ls_object/test/fixtures/sample-app/views/not_found.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/not_found.erb
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>not found</title>
+</head>
+<body>
+  <h1>404</h1>
+  <p>This is nowhere to be found.</p>
+</body>
+</html>

--- a/07.ls_object/test/fixtures/sample-app/views/show.erb
+++ b/07.ls_object/test/fixtures/sample-app/views/show.erb
@@ -1,0 +1,9 @@
+<h2><%== @memo[:title] %></h2>
+<p><%== @memo[:content] %></p>
+<div class="container">
+  <button><a href="/memos/<%= @memo[:id] %>/edit">変更</a></button>
+  <form method="POST" action="/memos/<%= @memo[:id] %>">
+    <button>削除</button>
+    <input type="hidden" name="_method" value="DELETE">
+  </form>
+</div>

--- a/07.ls_object/test/ls_command_test.rb
+++ b/07.ls_object/test/ls_command_test.rb
@@ -56,4 +56,9 @@ class LsCommandTest < Minitest::Test
   def test_run_long_format_empty_dir
     assert_equal 'total 0', LsCommand.new(EMPTY_DIR_PATH, long_format: true).run
   end
+
+  def test_run_all_options
+    expected = `ls -alr #{DIR_PATH}`.chomp
+    assert_equal expected, LsCommand.new(DIR_PATH, dot_match: true, long_format: true, reverse: true).run
+  end
 end

--- a/07.ls_object/test/ls_command_test.rb
+++ b/07.ls_object/test/ls_command_test.rb
@@ -29,4 +29,13 @@ class LsCommandTest < Minitest::Test
     TEXT
     assert_equal expected, LsCommand.new(DIR_PATH, dot_match: true).run
   end
+
+  def test_run_reverse
+    expected = <<~TEXT.chomp
+      views           app.rb          Gemfile
+      public          README.md
+      dbinit.sh       Gemfile.lock
+    TEXT
+    assert_equal expected, LsCommand.new(DIR_PATH, reverse: true).run
+  end
 end

--- a/07.ls_object/test/ls_command_test.rb
+++ b/07.ls_object/test/ls_command_test.rb
@@ -19,4 +19,14 @@ class LsCommandTest < Minitest::Test
   def test_run_empty_dir
     assert_equal '', LsCommand.new(EMPTY_DIR_PATH).run
   end
+
+  def test_run_dot_match
+    expected = <<~TEXT.chomp
+      .               .rubocop.yml    app.rb
+      ..              Gemfile         dbinit.sh
+      .erb-lint.yml   Gemfile.lock    public
+      .gitignore      README.md       views
+    TEXT
+    assert_equal expected, LsCommand.new(DIR_PATH, dot_match: true).run
+  end
 end

--- a/07.ls_object/test/ls_command_test.rb
+++ b/07.ls_object/test/ls_command_test.rb
@@ -38,4 +38,22 @@ class LsCommandTest < Minitest::Test
     TEXT
     assert_equal expected, LsCommand.new(DIR_PATH, reverse: true).run
   end
+
+  def test_run_long_format
+    # Output example
+    # total 40
+    # -rw-r--r--  1 ryufuta  staff   232 Oct  4 18:14 Gemfile
+    # -rw-r--r--  1 ryufuta  staff  3098 Oct  4 18:14 Gemfile.lock
+    # -rw-r--r--  1 ryufuta  staff   429 Dec 10  2023 README.md
+    # -rw-r--r--  1 ryufuta  staff  1787 Oct  4 18:14 app.rb
+    # -rwxr-xr-x  1 ryufuta  staff   279 Oct  4 18:14 dbinit.sh
+    # drwxr-xr-x  3 ryufuta  staff    96 Oct  4 18:14 public
+    # drwxr-xr-x  8 ryufuta  staff   256 Oct  4 18:14 views
+    expected = `ls -l #{DIR_PATH}`.chomp
+    assert_equal expected, LsCommand.new(DIR_PATH, long_format: true).run
+  end
+
+  def test_run_long_format_empty_dir
+    assert_equal 'total 0', LsCommand.new(EMPTY_DIR_PATH, long_format: true).run
+  end
 end

--- a/07.ls_object/test/ls_command_test.rb
+++ b/07.ls_object/test/ls_command_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'minitest/autorun'
+require_relative '../lib/ls_command'
+
+class LsCommandTest < Minitest::Test
+  DIR_PATH = 'test/fixtures/sample-app'
+  EMPTY_DIR_PATH = 'test/fixtures/empty_dir'
+
+  def test_run
+    expected = <<~TEXT.chomp
+      Gemfile         app.rb          views
+      Gemfile.lock    dbinit.sh
+      README.md       public
+    TEXT
+    assert_equal expected, LsCommand.new(DIR_PATH).run
+  end
+
+  def test_run_empty_dir
+    assert_equal '', LsCommand.new(EMPTY_DIR_PATH).run
+  end
+end


### PR DESCRIPTION
macOSのlsコマンドを模倣しました。

- やったこと
  - 必須要件
  - コマンドライン引数にディレクトリを1つだけ指定可能にした
  - 6ヶ月以上前に更新したファイルのmtimeの表記がOSのコマンドと同じになるようにした
- やらなかったこと
  - コマンドライン引数を2つ以上指定
  - コマンドライン引数にファイルや存在しないパスを指定
  - 拡張ファイル属性やACLの表示
  - ターミナルの幅に応じた表示変更
  - 日本語ファイル名があっても整列表示される
  - ファイルとディレクトリ以外のファイルタイプを表示
  - 特殊なファイルアクセス権限を表示